### PR TITLE
Fix fs.promises and fetch adapter

### DIFF
--- a/src/adapter/fetch.test.ts
+++ b/src/adapter/fetch.test.ts
@@ -67,19 +67,33 @@ describe('core - fetch adapter', () => {
 		expect(response.statusText).toBe('OK')
 	})
 
-	it('should enforce CORS policy if enabled', async () => {
-		const adapterOptions: GetFetchAdapterOptions = {
-			corsCheck: true,
-		}
-		const fetchAdapter = getDefaultFetchAdapter(adapterOptions)
+        it('should enforce CORS policy if enabled', async () => {
+                const adapterOptions: GetFetchAdapterOptions = {
+                        corsCheck: true,
+                }
+                const fetchAdapter = getDefaultFetchAdapter(adapterOptions)
 
 		// Mocking fetch to return a response without CORS headers
 		global.fetch = Object.assign(mock().mockResolvedValue(new Response('', { status: 200, statusText: 'OK' })), {
 			preconnect: async () => {},
 		})
 
-		const response = await fetchAdapter('http://example.com')
-		expect(response.status).toBe(403)
-		expect(response.statusText).toBe('FORBIDDEN')
-	})
+                const response = await fetchAdapter('http://example.com')
+                expect(response.status).toBe(403)
+                expect(response.statusText).toBe('FORBIDDEN')
+        })
+
+        it('should handle Request objects', async () => {
+                const fetchAdapter = getDefaultFetchAdapter({})
+
+                // Mock fetch to avoid real network call
+                global.fetch = Object.assign(mock().mockResolvedValue(new Response('', { status: 200, statusText: 'OK' })), {
+                        preconnect: async () => {},
+                })
+
+                const req = new Request('http://example.com')
+                const response = await fetchAdapter(req)
+                expect(response.status).toBe(200)
+                expect(response.statusText).toBe('OK')
+        })
 })

--- a/src/adapter/fetch.ts
+++ b/src/adapter/fetch.ts
@@ -111,10 +111,18 @@ export const getDefaultFetchAdapter = (adapterOptions: GetFetchAdapterOptions = 
 	})
 
 	const fetchAdapter = Object.assign(
-		async (input: RequestInfo, init?: RequestInit) => {
-			try {
-				await rateLimiter.consume('fetch', 1)
-				const parsedUrl = new URL(input.toString())
+                async (input: RequestInfo, init?: RequestInit) => {
+                        try {
+                                await rateLimiter.consume('fetch', 1)
+                                let urlString: string
+                                if (typeof input === 'string') {
+                                        urlString = input
+                                } else if (input instanceof URL) {
+                                        urlString = input.toString()
+                                } else {
+                                        urlString = input.url
+                                }
+                                const parsedUrl = new URL(urlString)
 
 				// Check disallowed hosts
 				if (options.disallowedHosts.includes(parsedUrl.hostname)) {
@@ -132,18 +140,19 @@ export const getDefaultFetchAdapter = (adapterOptions: GetFetchAdapterOptions = 
 				}
 
 				// Handle file:// protocol with virtual file system
-				if (parsedUrl.protocol === 'file:') {
-					if (!options.fs) {
-						return getForbiddenResponse()
-					}
-					if (!options.fs.existsSync(input.toString())) {
-						const res = new Response('', { status: 404, statusText: 'NOT_FOUND' })
-						return mapResponse(res)
-					}
-					const content = options.fs.readFileSync(input.toString())
-					const res = new Response(content, { status: 200, statusText: 'OK' })
-					return mapResponse(res)
-				}
+                                if (parsedUrl.protocol === 'file:') {
+                                        if (!options.fs) {
+                                                return getForbiddenResponse()
+                                        }
+                                        const filePath = parsedUrl.pathname
+                                        if (!options.fs.existsSync(filePath)) {
+                                                const res = new Response('', { status: 404, statusText: 'NOT_FOUND' })
+                                                return mapResponse(res)
+                                        }
+                                        const content = options.fs.readFileSync(filePath)
+                                        const res = new Response(content, { status: 200, statusText: 'OK' })
+                                        return mapResponse(res)
+                                }
 
 				// Setup request with timeout
 				const initWithDefaults: RequestInit = {

--- a/src/modules/fs_promises.js
+++ b/src/modules/fs_promises.js
@@ -52,7 +52,7 @@ export const close = (fd) => new Promise((resolve, reject) => {
 })
 
 export const copyFile = (src, dest, mode) => new Promise((resolve, reject) => {
-    __fs.copyFile(pathResolve(src), pathResolve(dst), mode, (err) => {
+    __fs.copyFile(pathResolve(src), pathResolve(dest), mode, (err) => {
         if (err) {
             reject(err)
         } else {
@@ -65,7 +65,7 @@ export const createReadStream = (...params) => __fs.createReadStream(...params)
 export const createWriteStream = (...params) => __fs.createWriteStream(...params)
 
 export const exists = (path) => new Promise((resolve) => {
-    __fs.exists(pathResolve(file), (exists) => {
+    __fs.exists(pathResolve(path), (exists) => {
         resolve(exists)
     })
 })
@@ -141,7 +141,7 @@ export const futimes = (fd, atime, mtime) => new Promise((resolve, reject) => {
 })
 
 export const lchmod = (path, mode) => new Promise((resolve, reject) => {
-    __fs.lchmod(pathResolve(file), mode, (err) => {
+    __fs.lchmod(pathResolve(path), mode, (err) => {
         if (err) {
             reject(err)
         } else {
@@ -151,7 +151,7 @@ export const lchmod = (path, mode) => new Promise((resolve, reject) => {
 })
 
 export const lchown = (path, uid, gid) => new Promise((resolve, reject) => {
-    __fs.lchown(pathResolve(file), uid, gid, (err) => {
+    __fs.lchown(pathResolve(path), uid, gid, (err) => {
         if (err) {
             reject(err)
         } else {
@@ -171,7 +171,7 @@ export const link = (existingPath, newPath) => new Promise((resolve, reject) => 
 })
 
 export const lstat = (path) => new Promise((resolve, reject) => {
-    __fs.lstat(pathResolve(file), (err, stats) => {
+    __fs.lstat(pathResolve(path), (err, stats) => {
         if (err) {
             reject(err)
         } else {
@@ -232,12 +232,12 @@ export const readFile = (path, options) => new Promise((resolve, reject) => {
       const res = __fs.readFileSync(pathResolve(path), options)
       resolve(res)
     } catch (err) {
-      resolve(err)
+      reject(err)
     }
 })
 
 export const readlink = (path, options) => new Promise((resolve, reject) => {
-    __fs.readlink(pathResolve(file), options, (err, linkString) => {
+    __fs.readlink(pathResolve(path), options, (err, linkString) => {
         if (err) {
             reject(err)
         } else {
@@ -247,7 +247,7 @@ export const readlink = (path, options) => new Promise((resolve, reject) => {
 })
 
 export const realpath = (path, options) => new Promise((resolve, reject) => {
-    __fs.realpath(pathResolve(file), options, (err, resolvedPath) => {
+    __fs.realpath(pathResolve(path), options, (err, resolvedPath) => {
         if (err) {
             reject(err)
         } else {
@@ -296,7 +296,7 @@ export const symlink = (target, path, type) => new Promise((resolve, reject) => 
 })
 
 export const truncate = (path, len) => new Promise((resolve, reject) => {
-    __fs.truncate(pathResolve(file), len, (err) => {
+    __fs.truncate(pathResolve(path), len, (err) => {
         if (err) {
             reject(err)
         } else {
@@ -306,7 +306,7 @@ export const truncate = (path, len) => new Promise((resolve, reject) => {
 })
 
 export const unlink = (path) => new Promise((resolve, reject) => {
-    __fs.unlink(pathResolve(file), (err) => {
+    __fs.unlink(pathResolve(path), (err) => {
         if (err) {
             reject(err)
         } else {
@@ -316,7 +316,7 @@ export const unlink = (path) => new Promise((resolve, reject) => {
 })
 
 export const utimes = (path, atime, mtime) => new Promise((resolve, reject) => {
-    __fs.utimes(pathResolve(file), atime, mtime, (err) => {
+    __fs.utimes(pathResolve(path), atime, mtime, (err) => {
         if (err) {
             reject(err)
         } else {


### PR DESCRIPTION
## Summary
- fix broken variable usage in fs.promises implementation
- improve fetch adapter to accept Request objects and fix file:// handling
- add regression test for Request handling in fetch adapter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68554836a5dc8328ac948d96b72da2a0