### PR TITLE
Update docs for accuracy

### DIFF
--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -108,7 +108,7 @@ This library will be aligned soon, to support cloudflare as well.
 ## Usage in Browser
 
 Here is the most minimal example on how to use this library in the browser.
-You need to ensure, that the webassembly file can be loaded correctly. Therefore, you need to add this as parameter to the `quickJS` call.
+You need to ensure that the WebAssembly file can be loaded correctly. Therefore, you must pass its location to the `loadQuickJs` call.
 
 Using `fetch`is possible, but there are the same restrictions as in any other browser usage (CORS & co).
 

--- a/website/docs/runtime-options.md
+++ b/website/docs/runtime-options.md
@@ -81,8 +81,8 @@ To prevent abuse, the number of running `setTimeout` and `setInterval` calls is 
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `maxTimeoutCount` | `number` | Max concurrent timeouts (default: `100`). |
-| `maxIntervalCount` | `number` | Max concurrent intervals (default: `100`). |
+| `maxTimeoutCount` | `number` | Max concurrent timeouts (default: `10`). |
+| `maxIntervalCount` | `number` | Max concurrent intervals (default: `10`). |
 
 ---
 
@@ -108,7 +108,7 @@ Both **synchronous** and **asynchronous** QuickJS sandboxes allow customizing mo
 
 ## Example Usage
 
-The options are passed to the `createRuntime` method. Here is a basic example:
+The options are passed to the `runSandboxed` function. Here is a basic example:
 
 ```typescript
 import { type SandboxOptions, loadQuickJs } from '@sebastianwessel/quickjs'

--- a/website/docs/typescript-usage.md
+++ b/website/docs/typescript-usage.md
@@ -14,14 +14,14 @@ If checking types is required, it should be done and handled, before using this 
 **Requirements:**
 
 - optional dependency package `typescript` must be installed on the host system
-- `createRuntime` option `transformTypescript` must be set to `true`
+- Sandbox option `transformTypescript` must be set to `true`
 
 Example:
 
 ```typescript
-import { quickJS } from '@sebastianwessel/quickjs'
+import { loadQuickJs } from '@sebastianwessel/quickjs'
 
-const { createRuntime } = await quickJS()
+const { runSandboxed } = await loadQuickJs()
 
 const options:SandboxOptions = {
   transformTypescript: true, // [!code ++] enable typescript support
@@ -36,15 +36,15 @@ const options:SandboxOptions = {
 }
 
 
-const result = await evalCode(`
-import { testFn } from './test.js'
+const result = await runSandboxed(async ({ evalCode }) => evalCode(`
+  import { testFn } from './test.js'
 
 const t = (value:string):number=>value.length
 
 console.log(t('abc'))
   
 export default testFn('hello')
-`)
+`), options)
 
 console.log(result) // { ok: true, data: 'hello' }
 // console log on host:


### PR DESCRIPTION
## Summary
- update default timer limit docs
- fix instructions referencing outdated API

## Testing
- `bun test` *(fails: Cannot find package 'quickjs-emscripten-core')*

------
https://chatgpt.com/codex/tasks/task_e_685552fe8bb88328ba348a48dd535e2f