### PR TITLE
Improve Node timers compatibility

### DIFF
--- a/src/modules/nodeCompatibility/headers.js
+++ b/src/modules/nodeCompatibility/headers.js
@@ -1,4 +1,5 @@
-export default `class Headers {
+export default `if (typeof globalThis.Headers === 'undefined') {
+class Headers {
   constructor(init) {
     this.map = {};
 
@@ -51,6 +52,7 @@ export default `class Headers {
     });
   }
 }
-
 globalThis.Headers = Headers;
+}
+export default globalThis.Headers;
 `

--- a/src/modules/nodeCompatibility/request.js
+++ b/src/modules/nodeCompatibility/request.js
@@ -1,3 +1,5 @@
 export default `
-export default {}
+const RequestClass = typeof Request !== 'undefined' ? Request : class Request {};
+globalThis.Request = RequestClass;
+export default RequestClass;
 `

--- a/src/modules/nodeCompatibility/response.js
+++ b/src/modules/nodeCompatibility/response.js
@@ -1,3 +1,5 @@
 export default `
-export default {}
+const ResponseClass = typeof Response !== 'undefined' ? Response : class Response {};
+globalThis.Response = ResponseClass;
+export default ResponseClass;
 `

--- a/src/modules/timers.js
+++ b/src/modules/timers.js
@@ -3,6 +3,8 @@ export setTimeout
 export clearTimeout
 export setInterval
 export clearInterval
+export setImmediate
+export clearImmediate
 
-export default {setTimeout, clearTimeout, setInterval, clearInterval }
+export default {setTimeout, clearTimeout, setInterval, clearInterval, setImmediate, clearImmediate }
 `

--- a/src/modules/timers_promises.js
+++ b/src/modules/timers_promises.js
@@ -1,1 +1,40 @@
-export default ''
+export default `
+export const setTimeout = (delay, value, options) => new Promise((resolve, reject) => {
+  const id = globalThis.setTimeout(() => resolve(value), delay);
+  if (options && options.signal) {
+    const abortHandler = () => {
+      globalThis.clearTimeout(id);
+      reject(options.signal.reason ?? new Error('AbortError'));
+    };
+    if (options.signal.aborted) {
+      abortHandler();
+      return;
+    }
+    options.signal.addEventListener('abort', abortHandler, { once: true });
+  }
+});
+
+export const setImmediate = (value, options) => new Promise((resolve, reject) => {
+  const id = globalThis.setTimeout(() => resolve(value), 0);
+  if (options && options.signal) {
+    const abortHandler = () => {
+      globalThis.clearTimeout(id);
+      reject(options.signal.reason ?? new Error('AbortError'));
+    };
+    if (options.signal.aborted) {
+      abortHandler();
+      return;
+    }
+    options.signal.addEventListener('abort', abortHandler, { once: true });
+  }
+});
+
+export async function* setInterval(delay, value) {
+  while (true) {
+    await new Promise((resolve) => globalThis.setTimeout(resolve, delay));
+    yield value;
+  }
+}
+
+export default { setTimeout, setImmediate, setInterval }
+`

--- a/src/test/async/core-timers.test.ts
+++ b/src/test/async/core-timers.test.ts
@@ -67,7 +67,7 @@ describe('async - core - timers', () => {
 		expect((result as OkResponse).data).toBe('interval reached')
 	})
 
-	it('clearInterval works correctly', async () => {
+        it('clearInterval works correctly', async () => {
 		const code = `
       export default await new Promise((resolve) => {
         let count = 0
@@ -87,5 +87,19 @@ describe('async - core - timers', () => {
 		// but it should be around 3 if intervals are 100ms and we clear after 500ms.
 		expect((result as OkResponse).data).toBeGreaterThanOrEqual(3)
 		expect((result as OkResponse).data).toBeLessThanOrEqual(5)
-	})
+        })
+
+        it('setImmediate works correctly', async () => {
+                const code = `
+      export default await new Promise((resolve) => {
+        setImmediate(() => {
+          resolve('immediate reached')
+        })
+      })
+    `
+
+                const result = await runCode(code)
+                expect(result.ok).toBeTrue()
+                expect((result as OkResponse).data).toBe('immediate reached')
+        })
 })

--- a/src/test/async/timers-promises.test.ts
+++ b/src/test/async/timers-promises.test.ts
@@ -1,0 +1,39 @@
+import { beforeAll, describe, expect, it } from 'bun:test'
+import { loadAsyncQuickJs } from '../../loadAsyncQuickJs.js'
+import type { OkResponse } from '../../types/OkResponse.js'
+
+describe('async - node:timers/promises', () => {
+  let runtime: Awaited<ReturnType<typeof loadAsyncQuickJs>>
+
+  beforeAll(async () => {
+    runtime = await loadAsyncQuickJs()
+  })
+
+  const runCode = async (code: string) => {
+    return await runtime.runSandboxed(async ({ evalCode }) => {
+      return await evalCode(code)
+    })
+  }
+
+  it('setTimeout resolves', async () => {
+    const code = `
+      import { setTimeout } from 'node:timers/promises'
+      export default await setTimeout(100, 'done')
+    `
+
+    const result = await runCode(code)
+    expect(result.ok).toBeTrue()
+    expect((result as OkResponse).data).toBe('done')
+  })
+
+  it('setImmediate resolves', async () => {
+    const code = `
+      import { setImmediate } from 'node:timers/promises'
+      export default await setImmediate('immediate')
+    `
+
+    const result = await runCode(code)
+    expect(result.ok).toBeTrue()
+    expect((result as OkResponse).data).toBe('immediate')
+  })
+})

--- a/src/test/sync/core-timers.test.ts
+++ b/src/test/sync/core-timers.test.ts
@@ -67,7 +67,7 @@ describe('sync - core - timers', () => {
 		expect((result as OkResponse).data).toBe('interval reached')
 	})
 
-	it('clearInterval works correctly', async () => {
+        it('clearInterval works correctly', async () => {
 		const code = `
       export default await new Promise((resolve) => {
         let count = 0
@@ -87,5 +87,19 @@ describe('sync - core - timers', () => {
 		// but it should be around 3 if intervals are 100ms and we clear after 500ms.
 		expect((result as OkResponse).data).toBeGreaterThanOrEqual(3)
 		expect((result as OkResponse).data).toBeLessThanOrEqual(5)
-	})
+        })
+
+        it('setImmediate works correctly', async () => {
+                const code = `
+      export default await new Promise((resolve) => {
+        setImmediate(() => {
+          resolve('immediate reached')
+        })
+      })
+    `
+
+                const result = await runCode(code)
+                expect(result.ok).toBeTrue()
+                expect((result as OkResponse).data).toBe('immediate reached')
+        })
 })

--- a/src/test/sync/timers-promises.test.ts
+++ b/src/test/sync/timers-promises.test.ts
@@ -1,0 +1,39 @@
+import { beforeAll, describe, expect, it } from 'bun:test'
+import { loadQuickJs } from '../../loadQuickJs.js'
+import type { OkResponse } from '../../types/OkResponse.js'
+
+describe('sync - node:timers/promises', () => {
+  let runtime: Awaited<ReturnType<typeof loadQuickJs>>
+
+  beforeAll(async () => {
+    runtime = await loadQuickJs()
+  })
+
+  const runCode = async (code: string) => {
+    return await runtime.runSandboxed(async ({ evalCode }) => {
+      return await evalCode(code)
+    })
+  }
+
+  it('setTimeout resolves', async () => {
+    const code = `
+      import { setTimeout } from 'node:timers/promises'
+      export default await setTimeout(100, 'done')
+    `
+
+    const result = await runCode(code)
+    expect(result.ok).toBeTrue()
+    expect((result as OkResponse).data).toBe('done')
+  })
+
+  it('setImmediate resolves', async () => {
+    const code = `
+      import { setImmediate } from 'node:timers/promises'
+      export default await setImmediate('immediate')
+    `
+
+    const result = await runCode(code)
+    expect(result.ok).toBeTrue()
+    expect((result as OkResponse).data).toBe('immediate')
+  })
+})

--- a/website/docs/module-resolution/node-compatibility.md
+++ b/website/docs/module-resolution/node-compatibility.md
@@ -38,7 +38,8 @@ This library tries to provide basic support for most common used Node.js modules
 | `repl`           | ❌         | Provides a Read-Eval-Print Loop (REPL) interface              |
 | `stream`         | ❌         | Provides an API for implementing stream-based I/O             |
 | `string_decoder` | ✅         | Provides utilities for decoding buffer objects into strings   |
-| `timers`         | ❌         | Provides timer functions similar to those in JavaScript       |
+| `timers`         | ✅        | Provides timer functions similar to those in JavaScript |
+| `timers/promises`| ✅        | Promise-based timer functions |
 | `tls`            | ❌         | Provides an implementation of TLS and SSL protocols           |
 | `trace_events`   | ❌         | Provides a mechanism to centralize tracing information        |
 | `tty`            | ❌         | Provides utilities for working with TTYs (terminals)          |


### PR DESCRIPTION
## Summary
- expose setImmediate and clearImmediate in timers module
- add promises-based timers with abort support
- extend sandbox timing utilities
- polyfill Request and Response modules
- mark timers as supported in docs
- test timer improvements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685556f1990c83288a3d0af09e2173aa