### PR TITLE
Doc: add hint for setup with Vite

### DIFF
--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -105,6 +105,28 @@ Cloudflare workers have some limitations regarding bundling. The developers of t
 
 This library will be aligned soon, to support cloudflare as well.
 
+### Vite
+
+When bundling for the browser with [Vite](https://vitejs.dev/), the `memfs` dependency requires polyfills for Node.js built-in modules. Install a Node polyfill plugin and prebundle `memfs`:
+
+```ts
+import { defineConfig } from 'vite'
+import rollupNodePolyFill from 'rollup-plugin-polyfill-node'
+
+export default defineConfig({
+  plugins: [rollupNodePolyFill()],
+  optimizeDeps: {
+    include: ['memfs']
+  },
+  build: {
+    rollupOptions: {
+      plugins: [rollupNodePolyFill()]
+    }
+  }
+})
+```
+
+
 ## Usage in Browser
 
 Here is the most minimal example on how to use this library in the browser.


### PR DESCRIPTION
## Summary
- remove the link to Issue #73 from the Vite documentation snippet

## Testing
- `npm test` *(fails to find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68555b95d8848328bbd9ce70c4d39f3f