### PR TITLE
Enable fs link and permission tests

### DIFF
--- a/src/modules/fs_promises.js
+++ b/src/modules/fs_promises.js
@@ -2,13 +2,12 @@ export default `
 import { resolve as pathResolve } from 'node:path'
 
 export const access = (path, mode) => new Promise((resolve, reject) => {
-    __fs.access(pathResolve(path), mode, (err) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve()
-        }
-    })
+    try {
+        __fs.accessSync(pathResolve(path), mode)
+        resolve()
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const appendFile = (path, data, options) => new Promise((resolve, reject) => {
@@ -22,23 +21,21 @@ export const appendFile = (path, data, options) => new Promise((resolve, reject)
 })
 
 export const chmod = (path, mode) => new Promise((resolve, reject) => {
-    __fs.chmod(pathResolve(path), mode, (err) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve()
-        }
-    })
+    try {
+        __fs.chmodSync(pathResolve(path), mode)
+        resolve()
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const chown = (path, uid, gid) => new Promise((resolve, reject) => {
-    __fs.chown(pathResolve(path), uid, gid, (err) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve()
-        }
-    })
+    try {
+        __fs.chownSync(pathResolve(path), uid, gid)
+        resolve()
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const close = (fd) => new Promise((resolve, reject) => {
@@ -71,23 +68,21 @@ export const exists = (path) => new Promise((resolve) => {
 })
 
 export const fchmod = (path, mode) => new Promise((resolve, reject) => {
-    __fs.fchmod(pathResolve(path), mode, (err) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve()
-        }
-    })
+    try {
+        __fs.fchmodSync(pathResolve(path), mode)
+        resolve()
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const fchown = (path, uid, gid) => new Promise((resolve, reject) => {
-    __fs.fchown(pathResolve(path), uid, gid, (err) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve()
-        }
-    })
+    try {
+        __fs.fchownSync(pathResolve(path), uid, gid)
+        resolve()
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const fdatasync = (fd) => new Promise((resolve, reject) => {
@@ -101,13 +96,12 @@ export const fdatasync = (fd) => new Promise((resolve, reject) => {
 })
 
 export const fstat = (path) => new Promise((resolve, reject) => {
-    __fs.fstat(pathResolve(path), (err, stats) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve(stats)
-        }
-    })
+    try {
+        const stats = __fs.fstatSync(pathResolve(path))
+        resolve(stats)
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const fsync = (fd) => new Promise((resolve, reject) => {
@@ -121,63 +115,57 @@ export const fsync = (fd) => new Promise((resolve, reject) => {
 })
 
 export const ftruncate = (fd, len) => new Promise((resolve, reject) => {
-    __fs.ftruncate(fd, len, (err) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve()
-        }
-    })
+    try {
+        __fs.ftruncateSync(fd, len)
+        resolve()
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const futimes = (fd, atime, mtime) => new Promise((resolve, reject) => {
-    __fs.futimes(fd, atime, mtime, (err) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve()
-        }
-    })
+    try {
+        __fs.futimesSync(fd, atime, mtime)
+        resolve()
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const lchmod = (path, mode) => new Promise((resolve, reject) => {
-    __fs.lchmod(pathResolve(path), mode, (err) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve()
-        }
-    })
+    try {
+        __fs.lchmodSync(pathResolve(path), mode)
+        resolve()
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const lchown = (path, uid, gid) => new Promise((resolve, reject) => {
-    __fs.lchown(pathResolve(path), uid, gid, (err) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve()
-        }
-    })
+    try {
+        __fs.lchownSync(pathResolve(path), uid, gid)
+        resolve()
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const link = (existingPath, newPath) => new Promise((resolve, reject) => {
-    __fs.link(pathResolve(existingPath), pathResolve(newPath), (err) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve()
-        }
-    })
+    try {
+        __fs.linkSync(pathResolve(existingPath), pathResolve(newPath))
+        resolve()
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const lstat = (path) => new Promise((resolve, reject) => {
-    __fs.lstat(pathResolve(path), (err, stats) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve(stats)
-        }
-    })
+    try {
+        const stats = __fs.lstatSync(pathResolve(path))
+        resolve(stats)
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const mkdir = (path, options) => new Promise((resolve, reject) => {
@@ -237,23 +225,21 @@ export const readFile = (path, options) => new Promise((resolve, reject) => {
 })
 
 export const readlink = (path, options) => new Promise((resolve, reject) => {
-    __fs.readlink(pathResolve(path), options, (err, linkString) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve(linkString)
-        }
-    })
+    try {
+        const linkString = __fs.readlinkSync(pathResolve(path), options)
+        resolve(linkString)
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const realpath = (path, options) => new Promise((resolve, reject) => {
-    __fs.realpath(pathResolve(path), options, (err, resolvedPath) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve(resolvedPath)
-        }
-    })
+    try {
+        const resolvedPath = __fs.realpathSync(pathResolve(path), options)
+        resolve(resolvedPath)
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const rename = (oldPath, newPath) => new Promise((resolve, reject) => {
@@ -276,53 +262,48 @@ export const rmdir = (path) => new Promise((resolve, reject) => {
 })
 
 export const stat = (path) => new Promise((resolve, reject) => {
-    __fs.stat(pathResolve(path), (err, stats) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve(stats)
-        }
-    })
+    try {
+        const stats = __fs.statSync(pathResolve(path))
+        resolve(stats)
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const symlink = (target, path, type) => new Promise((resolve, reject) => {
-    __fs.symlink(target, pathResolve(path), type, (err) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve()
-        }
-    })
+    try {
+        __fs.symlinkSync(target, pathResolve(path), type)
+        resolve()
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const truncate = (path, len) => new Promise((resolve, reject) => {
-    __fs.truncate(pathResolve(path), len, (err) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve()
-        }
-    })
+    try {
+        __fs.truncateSync(pathResolve(path), len)
+        resolve()
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const unlink = (path) => new Promise((resolve, reject) => {
-    __fs.unlink(pathResolve(path), (err) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve()
-        }
-    })
+    try {
+        __fs.unlinkSync(pathResolve(path))
+        resolve()
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const utimes = (path, atime, mtime) => new Promise((resolve, reject) => {
-    __fs.utimes(pathResolve(path), atime, mtime, (err) => {
-        if (err) {
-            reject(err)
-        } else {
-            resolve()
-        }
-    })
+    try {
+        __fs.utimesSync(pathResolve(path), atime, mtime)
+        resolve()
+    } catch (err) {
+        reject(err)
+    }
 })
 
 export const write = (fd, buffer, offset, length, position) => new Promise((resolve, reject) => {

--- a/src/test/async/fsModule-links.test.ts
+++ b/src/test/async/fsModule-links.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, it } from 'bun:test'
 import { loadAsyncQuickJs } from '../../loadAsyncQuickJs.js'
 import type { OkResponse } from '../../types/OkResponse.js'
 
-describe.skip('async - node:fs - links', () => {
+describe('async - node:fs - links', () => {
 	let runtime: Awaited<ReturnType<typeof loadAsyncQuickJs>>
 	const testFilePath = '/test.txt'
 	const testFileContent = 'example content'

--- a/src/test/async/fsModule-permissions.test.ts
+++ b/src/test/async/fsModule-permissions.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, it } from 'bun:test'
 import { loadAsyncQuickJs } from '../../loadAsyncQuickJs.js'
 import type { OkResponse } from '../../types/OkResponse.js'
 
-describe.skip('async - node:fs - permissions', () => {
+describe('async - node:fs - permissions', () => {
 	let runtime: Awaited<ReturnType<typeof loadAsyncQuickJs>>
 	const testFilePath = '/test.txt'
 	const testFileContent = 'example content'

--- a/src/test/sync/fsModule-links.test.ts
+++ b/src/test/sync/fsModule-links.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, it } from 'bun:test'
 import { loadQuickJs } from '../../loadQuickJs.js'
 import type { OkResponse } from '../../types/OkResponse.js'
 
-describe.skip('sync - node:fs - links', () => {
+describe('sync - node:fs - links', () => {
 	let runtime: Awaited<ReturnType<typeof loadQuickJs>>
 	const testFilePath = '/test.txt'
 	const testFileContent = 'example content'

--- a/src/test/sync/fsModule-permissions.test.ts
+++ b/src/test/sync/fsModule-permissions.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, it } from 'bun:test'
 import { loadQuickJs } from '../../loadQuickJs.js'
 import type { OkResponse } from '../../types/OkResponse.js'
 
-describe.skip('sync - node:fs - permissions', () => {
+describe('sync - node:fs - permissions', () => {
 	let runtime: Awaited<ReturnType<typeof loadQuickJs>>
 	const testFilePath = '/test.txt'
 	const testFileContent = 'example content'


### PR DESCRIPTION
## Summary
- implement fs promises using sync methods to work in sandbox
- unskip link & permission tests

## Testing
- `bun test --timeout=1000`


------
https://chatgpt.com/codex/tasks/task_e_6855aa21ce048328aa6aef5ff6c6fa65