### PR TITLE
Implement Headers-like object for fetch response and add tests

### DIFF
--- a/src/sandbox/expose/expose.ts
+++ b/src/sandbox/expose/expose.ts
@@ -1,4 +1,5 @@
 import { type QuickJSAsyncContext, type QuickJSContext, type QuickJSHandle, Scope } from 'quickjs-emscripten-core'
+import { HEADERS_MARKER } from '../../adapter/fetch.js'
 import { handleToNative } from '../handleToNative/handleToNative.js'
 import { isES2015Class } from './isES2015Class.js'
 import { isObject } from './isObject.js'
@@ -17,6 +18,14 @@ export const getHandle = (
 	// null
 	if (input === undefined) {
 		return ctx.undefined
+	}
+
+	// Headers-like object - construct using sandbox's Headers class
+	if (input && typeof input === 'object' && HEADERS_MARKER in input && (input as any)._headers) {
+		const headersData = (input as any)._headers as Record<string, string>
+		const headersJson = JSON.stringify(headersData)
+		const result = ctx.evalCode(`new Headers(${headersJson})`)
+		return result.unwrap()
 	}
 
 	// Array Buffer

--- a/src/test/sync/fetch-headers.test.ts
+++ b/src/test/sync/fetch-headers.test.ts
@@ -1,0 +1,224 @@
+import { beforeAll, describe, expect, it, mock } from 'bun:test'
+import variant from '@jitl/quickjs-ng-wasmfile-release-sync'
+import { loadQuickJs } from '../../loadQuickJs.js'
+import type { OkResponse } from '../../types/OkResponse.js'
+
+describe('sync - fetch headers', () => {
+	let runtime: Awaited<ReturnType<typeof loadQuickJs>>
+
+	beforeAll(async () => {
+		runtime = await loadQuickJs(variant)
+	})
+
+	it('headers should be an instance of Headers', async () => {
+		// Mock fetch to return predictable headers
+		const originalFetch = global.fetch
+		global.fetch = Object.assign(
+			mock().mockResolvedValue(
+				new Response('test', {
+					status: 200,
+					statusText: 'OK',
+					headers: {
+						'Content-Type': 'text/plain',
+						'X-Custom-Header': 'custom-value',
+					},
+				}),
+			),
+			{ preconnect: async () => {} },
+		)
+
+		try {
+			const code = `
+				async function fn() {
+					const res = await fetch('http://example.com')
+					return {
+						isHeadersInstance: res.headers instanceof Headers,
+						hasGetMethod: typeof res.headers.get === 'function',
+						hasHasMethod: typeof res.headers.has === 'function',
+					}
+				}
+				export default await fn()
+			`
+
+			const result = await runtime.runSandboxed(async ({ evalCode }) => evalCode(code), {
+				allowFetch: true,
+			})
+
+			expect(result.ok).toBeTrue()
+			const data = (result as OkResponse).data as { isHeadersInstance: boolean; hasGetMethod: boolean; hasHasMethod: boolean }
+			expect(data.isHeadersInstance).toBeTrue()
+			expect(data.hasGetMethod).toBeTrue()
+			expect(data.hasHasMethod).toBeTrue()
+		} finally {
+			global.fetch = originalFetch
+		}
+	})
+
+	it('headers.get() should return correct values', async () => {
+		const originalFetch = global.fetch
+		global.fetch = Object.assign(
+			mock().mockResolvedValue(
+				new Response('test', {
+					status: 200,
+					statusText: 'OK',
+					headers: {
+						'Content-Type': 'application/json',
+						'X-Custom-Header': 'my-value',
+					},
+				}),
+			),
+			{ preconnect: async () => {} },
+		)
+
+		try {
+			const code = `
+				async function fn() {
+					const res = await fetch('http://example.com')
+					return {
+						contentType: res.headers.get('Content-Type'),
+						customHeader: res.headers.get('X-Custom-Header'),
+						missingHeader: res.headers.get('X-Missing'),
+					}
+				}
+				export default await fn()
+			`
+
+			const result = await runtime.runSandboxed(async ({ evalCode }) => evalCode(code), {
+				allowFetch: true,
+			})
+
+			expect(result.ok).toBeTrue()
+			const data = (result as OkResponse).data as { contentType: string; customHeader: string; missingHeader: string | null }
+			expect(data.contentType).toBe('application/json')
+			expect(data.customHeader).toBe('my-value')
+			expect(data.missingHeader).toBeNull()
+		} finally {
+			global.fetch = originalFetch
+		}
+	})
+
+	it('headers.has() should check header existence', async () => {
+		const originalFetch = global.fetch
+		global.fetch = Object.assign(
+			mock().mockResolvedValue(
+				new Response('test', {
+					status: 200,
+					statusText: 'OK',
+					headers: {
+						'Content-Type': 'text/html',
+					},
+				}),
+			),
+			{ preconnect: async () => {} },
+		)
+
+		try {
+			const code = `
+				async function fn() {
+					const res = await fetch('http://example.com')
+					return {
+						hasContentType: res.headers.has('Content-Type'),
+						hasMissing: res.headers.has('X-Missing'),
+					}
+				}
+				export default await fn()
+			`
+
+			const result = await runtime.runSandboxed(async ({ evalCode }) => evalCode(code), {
+				allowFetch: true,
+			})
+
+			expect(result.ok).toBeTrue()
+			const data = (result as OkResponse).data as { hasContentType: boolean; hasMissing: boolean }
+			expect(data.hasContentType).toBeTrue()
+			expect(data.hasMissing).toBeFalse()
+		} finally {
+			global.fetch = originalFetch
+		}
+	})
+
+	it('headers.get() should be case-insensitive', async () => {
+		const originalFetch = global.fetch
+		global.fetch = Object.assign(
+			mock().mockResolvedValue(
+				new Response('test', {
+					status: 200,
+					statusText: 'OK',
+					headers: {
+						'Content-Type': 'text/plain',
+					},
+				}),
+			),
+			{ preconnect: async () => {} },
+		)
+
+		try {
+			const code = `
+				async function fn() {
+					const res = await fetch('http://example.com')
+					return {
+						lowercase: res.headers.get('content-type'),
+						uppercase: res.headers.get('CONTENT-TYPE'),
+						mixedCase: res.headers.get('Content-Type'),
+					}
+				}
+				export default await fn()
+			`
+
+			const result = await runtime.runSandboxed(async ({ evalCode }) => evalCode(code), {
+				allowFetch: true,
+			})
+
+			expect(result.ok).toBeTrue()
+			const data = (result as OkResponse).data as { lowercase: string; uppercase: string; mixedCase: string }
+			expect(data.lowercase).toBe('text/plain')
+			expect(data.uppercase).toBe('text/plain')
+			expect(data.mixedCase).toBe('text/plain')
+		} finally {
+			global.fetch = originalFetch
+		}
+	})
+
+	it('headers should be iterable with forEach', async () => {
+		const originalFetch = global.fetch
+		global.fetch = Object.assign(
+			mock().mockResolvedValue(
+				new Response('test', {
+					status: 200,
+					statusText: 'OK',
+					headers: {
+						'X-Header-A': 'value-a',
+						'X-Header-B': 'value-b',
+					},
+				}),
+			),
+			{ preconnect: async () => {} },
+		)
+
+		try {
+			const code = `
+				async function fn() {
+					const res = await fetch('http://example.com')
+					const entries = []
+					res.headers.forEach((value, name) => {
+						entries.push({ name, value })
+					})
+					return { entries, count: entries.length }
+				}
+				export default await fn()
+			`
+
+			const result = await runtime.runSandboxed(async ({ evalCode }) => evalCode(code), {
+				allowFetch: true,
+			})
+
+			expect(result.ok).toBeTrue()
+			const data = (result as OkResponse).data as { count: number; entries: Array<{ name: string; value: string }> }
+			expect(data.count).toBeGreaterThanOrEqual(2)
+			expect(data.entries.some((e) => e.name === 'x-header-a' && e.value === 'value-a')).toBeTrue()
+			expect(data.entries.some((e) => e.name === 'x-header-b' && e.value === 'value-b')).toBeTrue()
+		} finally {
+			global.fetch = originalFetch
+		}
+	})
+})


### PR DESCRIPTION
Fixes #97

Upon a fetch response correctly serialize headers with type indicator and correctly reconstruct inside the sandbox, including implementation of Headers type object.

Tests passing