### PR TITLE
CI: remove release version input and fix trusted publish

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,9 +27,9 @@ jobs:
           bun run build
       - name: Test
         run: |
-          set -e
+          set -euo pipefail
           bunx tsc --noEmit
-          for f in $(rg --files src | rg '\.test\.ts$' | sort); do
+          for f in $(find src -type f -name '*.test.ts' | sort); do
             echo "Running $f"
             bun test "$f"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to release (must match package.json and jsr.json)"
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -27,28 +22,32 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: "https://registry.npmjs.org"
 
-      - name: Verify version sync
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
+      - name: Verify version sync and export version
+        id: version
         run: |
           node -e "
           const fs = require('node:fs');
           const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
           const jsr = JSON.parse(fs.readFileSync('jsr.json', 'utf8'));
-          const expected = process.env.INPUT_VERSION;
           if (pkg.version !== jsr.version) {
             throw new Error('package.json and jsr.json versions are not in sync');
           }
-          if (pkg.version !== expected) {
-            throw new Error('workflow input version does not match package.json/jsr.json version');
-          }
-          console.log('Version verified:', expected);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, 'value=' + pkg.version + '\n');
+          console.log('Version verified:', pkg.version);
           "
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Ensure version is unpublished
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          if npm view "@sebastianwessel/quickjs@${VERSION}" version >/dev/null 2>&1; then
+            echo "Version ${VERSION} is already published on npm."
+            exit 1
+          fi
 
       - name: Lint
         run: bun run lint
@@ -58,8 +57,8 @@ jobs:
 
       - name: Run tests (serial by file)
         run: |
-          set -e
-          for f in $(rg --files src | rg '\.test\.ts$' | sort); do
+          set -euo pipefail
+          for f in $(find src -type f -name '*.test.ts' | sort); do
             echo "Running $f"
             bun test "$f"
           done
@@ -68,6 +67,8 @@ jobs:
         run: bun run build
 
       - name: Publish to npm (trusted publishing)
+        env:
+          NODE_AUTH_TOKEN: ""
         run: npm publish --provenance --access public --ignore-scripts
 
       - name: Publish to JSR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Ensure release runs on main
+        if: github.ref_name != 'main'
+        run: |
+          echo "Release workflow must be triggered on the main branch."
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary 
- remove manual version input from the release workflow_dispatch trigger
- derive the release version from package.json/jsr.json and verify both are in sync
- fail early if that version is already published on npm
- fix test discovery in CI by replacing rg-based loops with find (rg is not guaranteed on runners)
- force npm trusted publishing path by clearing NODE_AUTH_TOKEN in publish step
 