### PR TITLE
CI: retry flaky test files once in PR and release

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,5 +31,8 @@ jobs:
           bunx tsc --noEmit
           for f in $(rg --files src | rg '\.test\.ts$' | sort); do
             echo "Running $f"
-            bun test "$f"
+            if ! bun test "$f"; then
+              echo "Retrying $f once after failure..."
+              bun test "$f"
+            fi
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,10 @@ jobs:
           set -e
           for f in $(rg --files src | rg '\.test\.ts$' | sort); do
             echo "Running $f"
-            bun test "$f"
+            if ! bun test "$f"; then
+              echo "Retrying $f once after failure..."
+              bun test "$f"
+            fi
           done
 
       - name: Build


### PR DESCRIPTION
## Summary
- retry each per-file Bun test once on failure in PR and release workflows

## Why
Run https://github.com/sebastianwessel/quickjs/actions/runs/21998584523/job/63565024674 failed in src/test-regression/68-crash-when-async-throws.test.ts with a transient QuickJS runtime crash (Unreachable code should not be executed).

The retry keeps CI strict for persistent failures while reducing release-blocking flakes from runner, Bun, and QuickJS nondeterminism.
