### PR TITLE
CI: fix npm trusted publishing (use npm 11)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install --global npm@^11.5.1
+          npm --version
 
       - name: Verify version sync and export version
         id: version


### PR DESCRIPTION
## Summary
- configure npm registry in setup-node for publish step
- upgrade npm to >=11.5.1 before release publishing

## Why
Run https://github.com/sebastianwessel/quickjs/actions/runs/21999000779/job/63566469263 failed at npm publish with ENEEDAUTH while using trusted publishing.

That runner used npm 10.9.4, but npm trusted publishing requires npm >=11.5.1. This update aligns the workflow with npm trusted publisher requirements.
