### PR TITLE
ci: generate test utilities before release tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Build test utilities
+        run: bun run build:vendor
+
       - name: Typecheck
         run: bunx tsc --noEmit
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"build": "bun run build:vendor && tshy && bun run build:copy",
 		"build:vendor": "bun vendor.ts",
 		"build:copy": "cp -R ./src/modules/build/ ./dist/esm/modules/build && cp -R ./src/modules/build/ ./dist/commonjs/modules/build",
-		"test": "tsc --noEmit && bun test",
+		"test": "bun run build:vendor && tsc --noEmit && bun test",
 		"test:dev": "bun test --watch",
 		"lint": "bunx @biomejs/biome check",
 		"lint:fix": "bunx @biomejs/biome check --write",


### PR DESCRIPTION
## Summary
- Generate the vendor test utility before release workflow typecheck/tests run.
- Make `bun run test` generate the same utility first, so clean local checkouts match CI.

## Root cause
The release workflow runs tests from a clean checkout before `bun run build` has generated `src/modules/build/test-lib.js`. That path is intentionally ignored via `src/modules/build`, but the new `enableTestUtils` regression reads it through `createVirtualFileSystem`, so the release job failed with:

```text
ENOENT: no such file or directory, open '.../src/modules/build/test-lib.js'
```

## Verification
- `bun run lint`
- `rm -f src/modules/build/test-lib.js && bun run build:vendor && bunx tsc --noEmit && for f in $(find src -type f -name '*.test.ts' | sort); do bun test "$f" || bun test "$f"; done`
- `bun run test` (`261 pass`, `0 fail`)
- `bun run build`

Note: `bun run docs:build` was also checked earlier and completed, but it regenerated unrelated changelog output from `git-cliff`; that generated `CHANGELOG.md` delta is intentionally not included in this PR.
